### PR TITLE
Refactor chef entrypoint to use chef.main() instead of run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+venv
 downloads/
 cache.sqlite
 __*
@@ -6,5 +7,4 @@ stash
 storage
 .ricecookerfilecache
 carousel_downloads
-carousel.xml
 cat.xml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,4 @@
-lxml
+le-utils>=0.1.9
+ricecooker>=0.6.16
+lxml>=4.2.1
+requests-cache>=0.4.13

--- a/souschef.py
+++ b/souschef.py
@@ -27,7 +27,7 @@ lessons = OrderedDict([('Elementary', [x for x in raw_lessons if x.grade == "K-4
 LOGGER = logging.getLogger()
 
 
-class PBSChef(SushiChef):
+class ArtsEdgeChef(SushiChef):
     channel_info = {
         'CHANNEL_SOURCE_DOMAIN': 'artsedge.kennedy-center.org/', # who is providing the content (e.g. learningequality.org)
         'CHANNEL_SOURCE_ID': 'artsedge',         # channel's unique id
@@ -113,12 +113,15 @@ def download_videos(jsonfile):
             if i == 4:
                 print ("Artificial quit")
                 break
-        
-def make_channel():
-    mychef = PBSChef()
-    # if you are having problems wth kolibri, delete your .ricecookerfilecache
-    args = {'token': os.environ['KOLIBRI_STUDIO_TOKEN'], 'reset': True, 'verbose': True}
-    options = {}
-    mychef.run(args, options)
 
-make_channel()
+
+if __name__ == '__main__':
+    """
+    Set the environment var `CONTENT_CURATION_TOKEN` (or `KOLIBRI_STUDIO_TOKEN`)
+    to your Kolibri Studio token, then call this script using:
+        python souschef.py  -v --reset
+    """
+    mychef = ArtsEdgeChef()
+    if 'KOLIBRI_STUDIO_TOKEN' in os.environ:
+        os.environ['CONTENT_CURATION_TOKEN'] = os.environ['KOLIBRI_STUDIO_TOKEN']
+    mychef.main()


### PR DESCRIPTION
  - changed entry point for chef script to use reguler .main() method to
avoid nomonitor issue
  - reads environment variable KOLIBRI_STUDIO_TOKEN and sets it to
CONTENT_CURATION_TOKEN the one ricecooker currently expects
  - In fiture versoin of ricecooker will be able to use STUDIO_TOKEN
  - updated requirements.txt
  - carousel.xml seems to be necessary for chef to run so shouldnt be ignored